### PR TITLE
[dep] Add inspec tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-results
+results/
+inspec.lock

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# dep
+
+Go dependency management tool
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,15 +1,65 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.dep?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=204&branchName=master)
+
 # dep
 
-Go dependency management tool
+Go dependency management tool.  See [documentation](https://github.com/golang/dep)
 
 ## Maintainers
 
-* The Habitat Maintainers: <humans@habitat.sh>
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
 Binary package
 
-## Usage
+### Use as Dependency
 
-*TODO: Add instructions for usage*
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+
+To add core/dep as a dependency, you can add one of the following to your plan file.
+
+##### Buildtime Dependency
+
+> pkg_build_deps=(core/dep)
+
+##### Runtime dependency
+
+> pkg_deps=(core/dep)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/dep --binlink``
+
+will add the following binaries to the PATH:
+
+* TODO - Copy the binlink output and then run ``bins``
+* TODO - Add binary
+* TODO - Add binary
+
+For example:
+
+```bash
+$ hab pkg install core/dep --binlink
+TODO: ADD THE OUTPUT HERE
+```
+
+##### Additional Steps
+
+TODO: ADD OR DELETE THIS SECTION AS NEEDED 
+
+To use core/dep as a stand alone binary, you must configure ...
+
+#### Using an example binary
+
+You can now use the binary as normal.  For example:
+
+``/bin/dep --help`` or ``dep --help``
+
+```bash
+$ dep --help
+TODO:  ADD SOME OUTPUT HERE, BUT NO MORE THAN 10-15 lines...
+```

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Binary packages can be set as runtime or build time dependencies. See [Defining 
 
 To add core/dep as a dependency, you can add one of the following to your plan file.
 
-##### Buildtime Dependency
+#### Buildtime Dependency
 
 > pkg_build_deps=(core/dep)
 
-##### Runtime dependency
+#### Runtime dependency
 
 > pkg_deps=(core/dep)
 
@@ -34,24 +34,22 @@ To install this plan, you should run the following commands to first install, an
 
 ``hab pkg install core/dep --binlink``
 
-will add the following binaries to the PATH:
+will add the following binary to the PATH:
 
-* TODO - Copy the binlink output and then run ``bins``
-* TODO - Add binary
-* TODO - Add binary
+* /bin/dep
 
 For example:
 
 ```bash
 $ hab pkg install core/dep --binlink
-TODO: ADD THE OUTPUT HERE
+» Installing core/dep
+☁ Determining latest version of core/dep in the 'stable' channel
+→ Found newer installed version (core/dep/0.5.0/20200819142056) than remote version (core/dep/0.5.0/20200404012129)
+→ Using core/dep/0.5.0/20200819142056
+★ Install of core/dep/0.5.0/20200819142056 complete with 0 new packages installed.
+» Binlinking dep from core/dep/0.5.0/20200819142056 into /bin
+★ Binlinked dep from core/dep/0.5.0/20200819142056 to /bin/dep
 ```
-
-##### Additional Steps
-
-TODO: ADD OR DELETE THIS SECTION AS NEEDED 
-
-To use core/dep as a stand alone binary, you must configure ...
 
 #### Using an example binary
 
@@ -61,5 +59,23 @@ You can now use the binary as normal.  For example:
 
 ```bash
 $ dep --help
-TODO:  ADD SOME OUTPUT HERE, BUT NO MORE THAN 10-15 lines...
+Dep is a tool for managing dependencies for Go projects
+
+Usage: "dep [command]"
+
+Commands:
+
+  init     Set up a new Go project, or migrate an existing one
+  status   Report the status of the project's dependencies
+  ensure   Ensure a dependency is safely vendored in the project
+  version  Show the dep version information
+  check    Check if imports, Gopkg.toml, and Gopkg.lock are in sync
+
+Examples:
+  dep init                               set up a new project
+  dep ensure                             install the project's dependencies
+  dep ensure -update                     update the locked versions of all dependencies
+  dep ensure -add github.com/pkg/errors  add a dependency to the project
+
+Use "dep help [command]" for more information about a command.
 ```

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name: 'dep'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/botanist.yml
+++ b/botanist.yml
@@ -1,0 +1,5 @@
+---
+owners:
+  - "@afiune"
+  - "@predominant"
+  - "@habitat-sh/habitat-core-plans-maintainers"

--- a/controls/dep_exists.rb
+++ b/controls/dep_exists.rb
@@ -15,7 +15,6 @@ control 'core-plans-dep-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
 
   ["dep"].each do |binary_name|

--- a/controls/dep_exists.rb
+++ b/controls/dep_exists.rb
@@ -1,0 +1,28 @@
+title 'Tests to confirm dep exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'dep')
+
+control 'core-plans-dep-exists' do
+  impact 1.0
+  title 'Ensure dep exists'
+  desc '
+  Verify dep by ensuring bin/dep 
+  (1) exists and
+  (2) is executable'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  ["dep"].each do |binary_name|
+      command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+      describe file(command_full_path) do
+        it { should exist }
+        it { should be_executable }
+      end
+  end
+end

--- a/controls/dep_works.rb
+++ b/controls/dep_works.rb
@@ -16,7 +16,6 @@ control 'core-plans-dep-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
   
   plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
@@ -26,7 +25,6 @@ control 'core-plans-dep-works' do
       its('exit_status') { should eq 0 }
       its('stdout') { should_not be_empty }
       its('stdout') { should match /dep:\s+version\s+:\s+v(#{plan_pkg_version})/ }
-      its('stderr') { should be_empty }
     end
   end
 end

--- a/controls/dep_works.rb
+++ b/controls/dep_works.rb
@@ -1,0 +1,32 @@
+title 'Tests to confirm dep works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'dep')
+
+control 'core-plans-dep-works' do
+  impact 1.0
+  title 'Ensure dep works as expected'
+  desc '
+  Verify dep by ensuring that
+  (1) its installation directory exists 
+  (2) it returns the expected version
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+  
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  ["dep"].each do |binary_name|
+    command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+    describe command("#{command_full_path} version") do
+      its('exit_status') { should eq 0 }
+      its('stdout') { should_not be_empty }
+      its('stdout') { should match /dep:\s+version\s+:\s+v(#{plan_pkg_version})/ }
+      its('stderr') { should be_empty }
+    end
+  end
+end

--- a/hooks/run
+++ b/hooks/run
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec 2>&1
-
-while true; do
-  echo "Sleeping ..."
-  sleep 10
-done

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {plan}
-title: Habitat Core Plan {plan}
+name: dep
+title: Habitat Core Plan dep
 maintainer: "The Core Planners <chef-core-planners@chef.io>"
-summary: InSpec controls for testing Habitat Core Plan {plan}
+summary: InSpec controls for testing Habitat Core Plan dep
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 4.18.108'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,28 @@
+pkg_name=dep
+pkg_origin=core
+pkg_version=0.5.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Go dependency management tool"
+pkg_license="BSD-3-Clause"
+pkg_source="https://github.com/golang/dep/cmd/dep"
+pkg_upstream_url="https://github.com/golang/dep"
+pkg_scaffolding="core/scaffolding-go"
+pkg_bin_dirs=(bin)
+
+do_download() {
+  scaffolding_go_download
+
+  pushd "${scaffolding_go_pkg_path}" >/dev/null
+  git reset --hard "v${pkg_version}"
+  popd >/dev/null
+}
+
+do_build() {
+  pushd "${scaffolding_go_pkg_path}/../.." >/dev/null
+  DEP_BUILD_ARCHS="amd64" DEP_BUILD_PLATFORMS="linux" bash -x hack/build-all.bash
+  popd >/dev/null
+}
+
+do_install() {
+  cp "${scaffolding_go_pkg_path}/../../release/dep-linux-amd64" "${pkg_prefix}/bin/dep"
+}


### PR DESCRIPTION
Add to chef_base_plans from core-plans
Remove ./hooks/run
Update documentation
Add inspec tests

All tests passing in hab studio:

```rspec
» Installing chef/inspec
☁ Determining latest version of chef/inspec in the 'stable' channel
→ Using chef/inspec/4.22.8/20200804103652
★ Install of chef/inspec/4.22.8/20200804103652 complete with 0 new packages installed.

Profile: Habitat Core Plan dep (dep)
Version: 0.1.0
Target:  local://

  ✔  core-plans-dep-works: Ensure dep works as expected
     ✔  Command: `hab pkg path core/dep` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/dep` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/dep` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/core/dep/0.5.0/20200819142056/bin/dep version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/core/dep/0.5.0/20200819142056/bin/dep version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/core/dep/0.5.0/20200819142056/bin/dep version` stdout is expected to match /dep:\s+version\s+:\s+v(0.5.0)/
     ✔  Command: `/hab/pkgs/core/dep/0.5.0/20200819142056/bin/dep version` stderr is expected to be empty
  ✔  core-plans-dep-exists: Ensure dep exists
     ✔  Command: `hab pkg path core/dep` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/dep` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/dep` stderr is expected to be empty
     ✔  File /hab/pkgs/core/dep/0.5.0/20200819142056/bin/dep is expected to exist
     ✔  File /hab/pkgs/core/dep/0.5.0/20200819142056/bin/dep is expected to be executable


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 12 successful, 0 failures, 0 skipped
```